### PR TITLE
Allow Python 3.6 usage.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 ]
 description = "Code to handle symbolic permissions like GNU chmod does ('a=rx,u+w')"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.6"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",


### PR DESCRIPTION
Python 3.6 is still widely deployed. RHEL 8 and its derivatives (CentOS 8 being the one which brings me here), is still supported in its "stream" flavour until the end of May 2024. Allowing this library to be used with a slightly older python would be quite helpful.